### PR TITLE
[KNOW-141] Add software catalog metadata file(s)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  title: ezcrypto
+  description: This catalog entity description has been auto-generated
+  tags: []
+  annotations:
+    appfolio.com/package-location: url:https://github.com/appfolio/ezcrypto/pkgs/rubygems/ezcrypto
+    appfolio.com/package-type: gem
+  name: ezcrypto
+spec:
+  type: library
+  lifecycle: unknown
+  owner: engineering


### PR DESCRIPTION
All Developer Portal component, resource, and api catalog metadata files are migrating to project repositories to lower the rate of effort for catalog maintenance. See [this Slack announcement](https://appfolio.slack.com/archives/C02A9D6U3/p1708547921002909).

[_Created by Sourcegraph batch change `modethirteen/migrate-developer-portal-catalog-metadata`._](https://sourcegraph.appf.io/users/modethirteen/batch-changes/migrate-developer-portal-catalog-metadata)